### PR TITLE
🏷️ Mark Python package as typed

### DIFF
--- a/mdopt/py.typed
+++ b/mdopt/py.typed
@@ -1,0 +1,2 @@
+# Instruct type checkers to look for inline type annotations in this package.
+# See PEP 561.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ maintainers = [
 readme = "README.md"
 keywords = [ "tensor networks", "quantum error correction", "discrete optimisation", "MPS", "MPO", "python", "decoding" ]
 requires-python = ">=3.10,<4.0"
+classifiers = [
+    "Typing :: Typed",
+]
 
 dependencies = [
     "scipy>=1.9.2,<2.0.0",


### PR DESCRIPTION
# Description

This PR officially marks the Python package as typed, so that dependent packages using this library as a dependency will not have mypy complain about missing type information.

See https://peps.python.org/pep-0561/ for more information on the respective file.
This PR also adds classifiers to the Python package metadata.

This is part of https://github.com/openjournals/joss-reviews/issues/9125

## Type of change

- [x] Python package configuration

# How Has This Been Tested?

No real testing necessary. This just adds configuration files.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
