### PR TITLE
📄 Add license information via PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ maintainers = [
 ]
 readme = "README.md"
 keywords = [ "tensor networks", "quantum error correction", "discrete optimisation", "MPS", "MPO", "python", "decoding" ]
+license = "MIT"
+license-files = ["LICENSE.md"]
 requires-python = ">=3.10,<4.0"
 
 dependencies = [


### PR DESCRIPTION
# Description

This PR adds proper license information to the Python package metadata according to PEP 639.

This is part of https://github.com/openjournals/joss-reviews/issues/9125

## Type of change

- [x] Python package metadata

# How Has This Been Tested?

Python package still builds as before.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
