### PR TITLE
Fix the GPU example: title, Colab reliability, and backend fallback

### DIFF
--- a/docs/source/notebooks/gpu_example.ipynb
+++ b/docs/source/notebooks/gpu_example.ipynb
@@ -238,7 +238,7 @@
         "## GPU run\n",
         "\n",
         "Same code, same parameters, with the CuPy backend.\n",
-        "If `GPU flag` prints `False`, the runtime has no GPU and `mdopt` silently fell\n",
+        "If `GPU flag` prints `False`, the runtime has no GPU and `mdopt` warned and fell\n",
         "back to numpy — switch the runtime to GPU and re-run this cell.\n"
       ]
     },

--- a/docs/source/notebooks/gpu_example.ipynb
+++ b/docs/source/notebooks/gpu_example.ipynb
@@ -141,9 +141,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "\n",
-    "!MDOPT_BACKEND=numpy BENCH_LABEL=CPU {sys.executable} bench.py\n"
+    "# `python` is the same interpreter the notebook runs on; the setup cell above\n",
+    "# already used it. Each benchmark runs as a separate process so that\n",
+    "# MDOPT_BACKEND is read fresh on import.\n",
+    "!MDOPT_BACKEND=numpy BENCH_LABEL=CPU python bench.py\n"
    ]
   },
   {
@@ -167,7 +168,7 @@
    "source": [
     "!nvidia-smi\n",
     "\n",
-    "!MDOPT_BACKEND=cupy BENCH_LABEL=GPU {sys.executable} bench.py\n"
+    "!MDOPT_BACKEND=cupy BENCH_LABEL=GPU python bench.py\n"
    ]
   }
  ],

--- a/docs/source/notebooks/gpu_example.ipynb
+++ b/docs/source/notebooks/gpu_example.ipynb
@@ -1,188 +1,311 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "6282ba43",
-   "metadata": {},
-   "source": [
-    "# GPU Backend Example\n",
-    "\n",
-    "This example shows how to run `mdopt` on a GPU through [CuPy](https://cupy.dev/),\n",
-    "and compares the cost of the same MPS-MPO contraction on CPU and GPU.\n",
-    "\n",
-    "`mdopt` picks its array backend from the `MDOPT_BACKEND` environment variable,\n",
-    "and it does so **once, when `mdopt.backend.array` is first imported**. A single\n",
-    "Python process therefore cannot switch backends after the fact. To keep this\n",
-    "notebook runnable top to bottom, each benchmark is launched in its own\n",
-    "subprocess with the appropriate `MDOPT_BACKEND` value, so no kernel restarts\n",
-    "are needed and both results end up in one run.\n",
-    "\n",
-    "To run this on Colab, first switch the runtime to a GPU:\n",
-    "**Runtime \u2192 Change runtime type \u2192 Hardware accelerator \u2192 GPU**.\n"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "6282ba43",
+      "metadata": {
+        "id": "6282ba43"
+      },
+      "source": [
+        "# GPU Backend Example\n",
+        "\n",
+        "This example shows how to run `mdopt` on a GPU through [CuPy](https://cupy.dev/),\n",
+        "and compares the cost of the same MPS-MPO contraction on CPU and GPU.\n",
+        "\n",
+        "`mdopt` picks its array backend from the `MDOPT_BACKEND` environment variable,\n",
+        "and it does so **once, when `mdopt.backend.array` is first imported**. A single\n",
+        "Python process therefore cannot switch backends after the fact. To keep this\n",
+        "notebook runnable top to bottom, each benchmark is launched in its own\n",
+        "subprocess with the appropriate `MDOPT_BACKEND` value, so no kernel restarts\n",
+        "are needed and both results end up in one run.\n",
+        "\n",
+        "To run this on Colab, first switch the runtime to a GPU:\n",
+        "**Runtime → Change runtime type → Hardware accelerator → GPU**.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a1b2c3d4",
+      "metadata": {
+        "id": "a1b2c3d4"
+      },
+      "source": [
+        "## Setup\n",
+        "\n",
+        "Install the packages and make sure numpy is in a consistent state.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "dac5ce7b",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "dac5ce7b",
+        "outputId": "7fe19d24-0427-4421-88a6-92d3405c3829"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m177.3/177.3 kB\u001b[0m \u001b[31m7.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.3/8.3 MB\u001b[0m \u001b[31m14.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m16.6/16.6 MB\u001b[0m \u001b[31m84.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m148.0/148.0 kB\u001b[0m \u001b[31m9.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.3/1.3 MB\u001b[0m \u001b[31m15.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m135.0/135.0 kB\u001b[0m \u001b[31m11.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m45.5/45.5 kB\u001b[0m \u001b[31m4.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/4.2 MB\u001b[0m \u001b[31m81.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m625.9/625.9 kB\u001b[0m \u001b[31m39.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.3/5.3 MB\u001b[0m \u001b[31m89.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.9/3.9 MB\u001b[0m \u001b[31m94.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m59.9/59.9 MB\u001b[0m \u001b[31m10.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Building wheel for mdopt (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Building wheel for sinter (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "cuml-cu12 26.2.0 requires numba<0.62.0,>=0.60.0, but you have numba 0.67.0 which is incompatible.\n",
+            "pytensor 2.38.3 requires numba<=0.65.1,>=0.58, but you have numba 0.67.0 which is incompatible.\n",
+            "cudf-cu12 26.2.1 requires numba<0.62.0,>=0.60.0, but you have numba 0.67.0 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m16.6/16.6 MB\u001b[0m \u001b[31m198.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "cuml-cu12 26.2.0 requires numba<0.62.0,>=0.60.0, but you have numba 0.67.0 which is incompatible.\n",
+            "pytensor 2.38.3 requires numba<=0.65.1,>=0.58, but you have numba 0.67.0 which is incompatible.\n",
+            "cudf-cu12 26.2.1 requires numba<0.62.0,>=0.60.0, but you have numba 0.67.0 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[0mnumpy 2.4.6 imports cleanly\n",
+            "Tesla T4, 580.82.07\n",
+            "cupy 14.0.1 | CUDA runtime 12090\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Install mdopt. Colab's GPU runtimes already ship CuPy, pinned to a version\n",
+        "# whose bundled CUDA runtime matches the driver on the VM. Reinstalling it pulls\n",
+        "# the latest wheel, which can need a newer driver than the VM has and then fails\n",
+        "# with \"cudaErrorInsufficientDriver\" once a CUDA call is made -- so we\n",
+        "# deliberately leave CuPy alone here.\n",
+        "!pip -q install \"git+https://github.com/quicophy/mdopt.git\"\n",
+        "\n",
+        "# mdopt requires numpy>=2.3, so pip upgrades the numpy that Colab preloads at\n",
+        "# startup. Because the old numpy is already imported by the running kernel, the\n",
+        "# upgrade can leave a mix of new Python files and the old compiled extension,\n",
+        "# which shows up as \"ImportError: cannot import name '_slice' from\n",
+        "# numpy._core.umath\". Reinstalling numpy once, cleanly, repairs that.\n",
+        "!pip -q install --force-reinstall --no-cache-dir \"numpy>=2.3,<2.5\"\n",
+        "\n",
+        "# Report the environment from *fresh* processes: this kernel may still hold the\n",
+        "# stale numpy, but the benchmarks below run in subprocesses and so pick up the\n",
+        "# repaired one. The driver and CUDA runtime versions are printed together, since\n",
+        "# a GPU run needs the driver to be new enough for the runtime CuPy was built for.\n",
+        "!python -c \"import numpy; print('numpy', numpy.__version__, 'imports cleanly')\"\n",
+        "!nvidia-smi --query-gpu=name,driver_version --format=csv,noheader || echo \"no GPU on this runtime\"\n",
+        "!python -c \"import cupy; print('cupy', cupy.__version__, '| CUDA runtime', cupy.cuda.runtime.runtimeGetVersion())\" || echo \"CuPy unavailable\"\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b2c3d4e5",
+      "metadata": {
+        "id": "b2c3d4e5"
+      },
+      "source": [
+        "Write the benchmark to a file so both runs execute exactly the same code.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "c3d4e5f6",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "c3d4e5f6",
+        "outputId": "6148bfc7-4234-4268-de26-c057504690be"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Writing bench.py\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%writefile bench.py\n",
+        "\"\"\"MPS-MPO contraction benchmark. The backend is chosen by MDOPT_BACKEND.\"\"\"\n",
+        "\n",
+        "import os\n",
+        "import time\n",
+        "\n",
+        "from tqdm import tqdm\n",
+        "\n",
+        "from mdopt.mps.utils import create_simple_product_state\n",
+        "from mdopt.utils.utils import create_random_mpo\n",
+        "from mdopt.contractor.contractor import mps_mpo_contract\n",
+        "from mdopt.backend import array as A\n",
+        "\n",
+        "LABEL = os.environ.get(\"BENCH_LABEL\", A.backend_name().upper())\n",
+        "\n",
+        "\n",
+        "def bench(num_sites=48, phys_dim=2, mpo_len=32, chi=256, reps=10):\n",
+        "    \"\"\"Time one MPS-MPO contraction, averaged over `reps` repetitions.\"\"\"\n",
+        "    mps = create_simple_product_state(\n",
+        "        num_sites=num_sites, which=\"0\", phys_dim=phys_dim\n",
+        "    )\n",
+        "    mpo = create_random_mpo(\n",
+        "        num_sites=mpo_len,\n",
+        "        bond_dimensions=[chi] * (mpo_len - 1),\n",
+        "        phys_dim=phys_dim,\n",
+        "        which=\"uniform\",\n",
+        "    )\n",
+        "\n",
+        "    # Warm-up, so one-off allocation and CUDA kernel compilation are not timed.\n",
+        "    mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
+        "    A.synchronize()\n",
+        "\n",
+        "    t0 = time.perf_counter()\n",
+        "    for _ in tqdm(range(reps)):\n",
+        "        mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
+        "    A.synchronize()\n",
+        "    t1 = time.perf_counter()\n",
+        "\n",
+        "    seconds = (t1 - t0) / reps\n",
+        "    print(f\"{LABEL}: {seconds:.4f} s per run\")\n",
+        "    return seconds\n",
+        "\n",
+        "\n",
+        "if __name__ == \"__main__\":\n",
+        "    print(f\"Backend: {A.backend_name()} | GPU flag: {A.GPU}\")\n",
+        "    bench()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d4e5f6a7",
+      "metadata": {
+        "id": "d4e5f6a7"
+      },
+      "source": [
+        "## CPU baseline\n",
+        "\n",
+        "Run with the numpy backend.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "e5f6a7b8",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "e5f6a7b8",
+        "outputId": "5ac972eb-451e-403f-b3a4-31f82129876d"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Backend: numpy | GPU flag: False\n",
+            "100% 10/10 [02:50<00:00, 17.05s/it]\n",
+            "CPU: 17.0527 s per run\n"
+          ]
+        }
+      ],
+      "source": [
+        "# `python` is the same interpreter the notebook runs on; the setup cell above\n",
+        "# already used it. Each benchmark runs as a separate process so that\n",
+        "# MDOPT_BACKEND is read fresh on import.\n",
+        "!MDOPT_BACKEND=numpy BENCH_LABEL=CPU python bench.py\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f6a7b8c9",
+      "metadata": {
+        "id": "f6a7b8c9"
+      },
+      "source": [
+        "## GPU run\n",
+        "\n",
+        "Same code, same parameters, with the CuPy backend.\n",
+        "If `GPU flag` prints `False`, the runtime has no GPU and `mdopt` silently fell\n",
+        "back to numpy — switch the runtime to GPU and re-run this cell.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "908d389e",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "908d389e",
+        "outputId": "49db5302-64d6-45df-c286-c653b066892f"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Sat Aug 22 21:00:20 2026       \n",
+            "+-----------------------------------------------------------------------------------------+\n",
+            "| NVIDIA-SMI 580.82.07              Driver Version: 580.82.07      CUDA Version: 13.0     |\n",
+            "+-----------------------------------------+------------------------+----------------------+\n",
+            "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
+            "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
+            "|                                         |                        |               MIG M. |\n",
+            "|=========================================+========================+======================|\n",
+            "|   0  Tesla T4                       Off |   00000000:00:04.0 Off |                    0 |\n",
+            "| N/A   48C    P8             12W /   70W |       0MiB /  15360MiB |      0%      Default |\n",
+            "|                                         |                        |                  N/A |\n",
+            "+-----------------------------------------+------------------------+----------------------+\n",
+            "\n",
+            "+-----------------------------------------------------------------------------------------+\n",
+            "| Processes:                                                                              |\n",
+            "|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |\n",
+            "|        ID   ID                                                               Usage      |\n",
+            "|=========================================================================================|\n",
+            "|  No running processes found                                                             |\n",
+            "+-----------------------------------------------------------------------------------------+\n",
+            "Backend: cupy | GPU flag: True\n",
+            "100% 10/10 [00:04<00:00,  2.04it/s]\n",
+            "GPU: 0.4911 s per run\n"
+          ]
+        }
+      ],
+      "source": [
+        "!nvidia-smi\n",
+        "\n",
+        "!MDOPT_BACKEND=cupy BENCH_LABEL=GPU python bench.py\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.16"
+    },
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4"
+    },
+    "accelerator": "GPU"
   },
-  {
-   "cell_type": "markdown",
-   "id": "a1b2c3d4",
-   "metadata": {},
-   "source": [
-    "## Setup\n",
-    "\n",
-    "Install the packages and make sure numpy is in a consistent state.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dac5ce7b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install mdopt. Colab's GPU runtimes already ship CuPy, pinned to a version\n",
-    "# whose bundled CUDA runtime matches the driver on the VM. Reinstalling it pulls\n",
-    "# the latest wheel, which can need a newer driver than the VM has and then fails\n",
-    "# with \"cudaErrorInsufficientDriver\" once a CUDA call is made -- so we\n",
-    "# deliberately leave CuPy alone here.\n",
-    "!pip -q install \"git+https://github.com/quicophy/mdopt.git\"\n",
-    "\n",
-    "# mdopt requires numpy>=2.3, so pip upgrades the numpy that Colab preloads at\n",
-    "# startup. Because the old numpy is already imported by the running kernel, the\n",
-    "# upgrade can leave a mix of new Python files and the old compiled extension,\n",
-    "# which shows up as \"ImportError: cannot import name '_slice' from\n",
-    "# numpy._core.umath\". Reinstalling numpy once, cleanly, repairs that.\n",
-    "!pip -q install --force-reinstall --no-cache-dir \"numpy>=2.3,<2.5\"\n",
-    "\n",
-    "# Report the environment from *fresh* processes: this kernel may still hold the\n",
-    "# stale numpy, but the benchmarks below run in subprocesses and so pick up the\n",
-    "# repaired one. The driver and CUDA runtime versions are printed together, since\n",
-    "# a GPU run needs the driver to be new enough for the runtime CuPy was built for.\n",
-    "!python -c \"import numpy; print('numpy', numpy.__version__, 'imports cleanly')\"\n",
-    "!nvidia-smi --query-gpu=name,driver_version --format=csv,noheader || echo \"no GPU on this runtime\"\n",
-    "!python -c \"import cupy; print('cupy', cupy.__version__, '| CUDA runtime', cupy.cuda.runtime.runtimeGetVersion())\" || echo \"CuPy unavailable\"\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b2c3d4e5",
-   "metadata": {},
-   "source": [
-    "Write the benchmark to a file so both runs execute exactly the same code.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c3d4e5f6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile bench.py\n",
-    "\"\"\"MPS-MPO contraction benchmark. The backend is chosen by MDOPT_BACKEND.\"\"\"\n",
-    "\n",
-    "import os\n",
-    "import time\n",
-    "\n",
-    "from tqdm import tqdm\n",
-    "\n",
-    "from mdopt.mps.utils import create_simple_product_state\n",
-    "from mdopt.utils.utils import create_random_mpo\n",
-    "from mdopt.contractor.contractor import mps_mpo_contract\n",
-    "from mdopt.backend import array as A\n",
-    "\n",
-    "LABEL = os.environ.get(\"BENCH_LABEL\", A.backend_name().upper())\n",
-    "\n",
-    "\n",
-    "def bench(num_sites=48, phys_dim=2, mpo_len=32, chi=256, reps=10):\n",
-    "    \"\"\"Time one MPS-MPO contraction, averaged over `reps` repetitions.\"\"\"\n",
-    "    mps = create_simple_product_state(\n",
-    "        num_sites=num_sites, which=\"0\", phys_dim=phys_dim\n",
-    "    )\n",
-    "    mpo = create_random_mpo(\n",
-    "        num_sites=mpo_len,\n",
-    "        bond_dimensions=[chi] * (mpo_len - 1),\n",
-    "        phys_dim=phys_dim,\n",
-    "        which=\"uniform\",\n",
-    "    )\n",
-    "\n",
-    "    # Warm-up, so one-off allocation and CUDA kernel compilation are not timed.\n",
-    "    mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
-    "    A.synchronize()\n",
-    "\n",
-    "    t0 = time.perf_counter()\n",
-    "    for _ in tqdm(range(reps)):\n",
-    "        mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
-    "    A.synchronize()\n",
-    "    t1 = time.perf_counter()\n",
-    "\n",
-    "    seconds = (t1 - t0) / reps\n",
-    "    print(f\"{LABEL}: {seconds:.4f} s per run\")\n",
-    "    return seconds\n",
-    "\n",
-    "\n",
-    "if __name__ == \"__main__\":\n",
-    "    print(f\"Backend: {A.backend_name()} | GPU flag: {A.GPU}\")\n",
-    "    bench()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d4e5f6a7",
-   "metadata": {},
-   "source": [
-    "## CPU baseline\n",
-    "\n",
-    "Run with the numpy backend.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e5f6a7b8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# `python` is the same interpreter the notebook runs on; the setup cell above\n",
-    "# already used it. Each benchmark runs as a separate process so that\n",
-    "# MDOPT_BACKEND is read fresh on import.\n",
-    "!MDOPT_BACKEND=numpy BENCH_LABEL=CPU python bench.py\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f6a7b8c9",
-   "metadata": {},
-   "source": [
-    "## GPU run\n",
-    "\n",
-    "Same code, same parameters, with the CuPy backend.\n",
-    "If `GPU flag` prints `False`, the runtime has no GPU and `mdopt` silently fell\n",
-    "back to numpy \u2014 switch the runtime to GPU and re-run this cell.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "908d389e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!nvidia-smi\n",
-    "\n",
-    "!MDOPT_BACKEND=cupy BENCH_LABEL=GPU python bench.py\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "mdopt-ZdbamFdU-py3.10",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.10.16"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/docs/source/notebooks/gpu_example.ipynb
+++ b/docs/source/notebooks/gpu_example.ipynb
@@ -38,9 +38,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install mdopt and CuPy (the CuPy wheel matches Colab's CUDA 12 runtime).\n",
+    "# Install mdopt. Colab's GPU runtimes already ship CuPy, pinned to a version\n",
+    "# whose bundled CUDA runtime matches the driver on the VM. Reinstalling it pulls\n",
+    "# the latest wheel, which can need a newer driver than the VM has and then fails\n",
+    "# with \"cudaErrorInsufficientDriver\" once a CUDA call is made -- so we\n",
+    "# deliberately leave CuPy alone here.\n",
     "!pip -q install \"git+https://github.com/quicophy/mdopt.git\"\n",
-    "!pip -q install cupy-cuda12x\n",
     "\n",
     "# mdopt requires numpy>=2.3, so pip upgrades the numpy that Colab preloads at\n",
     "# startup. Because the old numpy is already imported by the running kernel, the\n",
@@ -49,9 +52,13 @@
     "# numpy._core.umath\". Reinstalling numpy once, cleanly, repairs that.\n",
     "!pip -q install --force-reinstall --no-cache-dir \"numpy>=2.3,<2.5\"\n",
     "\n",
-    "# Verify in a *fresh* process: this kernel may still hold the stale numpy, but\n",
-    "# the benchmarks below run in subprocesses and so pick up the repaired one.\n",
-    "!python -c \"import numpy; print('numpy', numpy.__version__, 'imports cleanly')\"\n"
+    "# Report the environment from *fresh* processes: this kernel may still hold the\n",
+    "# stale numpy, but the benchmarks below run in subprocesses and so pick up the\n",
+    "# repaired one. The driver and CUDA runtime versions are printed together, since\n",
+    "# a GPU run needs the driver to be new enough for the runtime CuPy was built for.\n",
+    "!python -c \"import numpy; print('numpy', numpy.__version__, 'imports cleanly')\"\n",
+    "!nvidia-smi --query-gpu=name,driver_version --format=csv,noheader || echo \"no GPU on this runtime\"\n",
+    "!python -c \"import cupy; print('cupy', cupy.__version__, '| CUDA runtime', cupy.cuda.runtime.runtimeGetVersion())\" || echo \"CuPy unavailable\"\n"
    ]
   },
   {

--- a/docs/source/notebooks/gpu_example.ipynb
+++ b/docs/source/notebooks/gpu_example.ipynb
@@ -5,6 +5,8 @@
    "id": "6282ba43",
    "metadata": {},
    "source": [
+    "# GPU Backend Example\n",
+    "\n",
     "This example is intended to show how to use CuPy to run mdopt on GPU. It has two blocks of code which are to be run in Colab to show the performance difference between CPU and GPU."
    ]
   },

--- a/docs/source/notebooks/gpu_example.ipynb
+++ b/docs/source/notebooks/gpu_example.ipynb
@@ -7,7 +7,28 @@
    "source": [
     "# GPU Backend Example\n",
     "\n",
-    "This example is intended to show how to use CuPy to run mdopt on GPU. It has two blocks of code which are to be run in Colab to show the performance difference between CPU and GPU."
+    "This example shows how to run `mdopt` on a GPU through [CuPy](https://cupy.dev/),\n",
+    "and compares the cost of the same MPS-MPO contraction on CPU and GPU.\n",
+    "\n",
+    "`mdopt` picks its array backend from the `MDOPT_BACKEND` environment variable,\n",
+    "and it does so **once, when `mdopt.backend.array` is first imported**. A single\n",
+    "Python process therefore cannot switch backends after the fact. To keep this\n",
+    "notebook runnable top to bottom, each benchmark is launched in its own\n",
+    "subprocess with the appropriate `MDOPT_BACKEND` value, so no kernel restarts\n",
+    "are needed and both results end up in one run.\n",
+    "\n",
+    "To run this on Colab, first switch the runtime to a GPU:\n",
+    "**Runtime \u2192 Change runtime type \u2192 Hardware accelerator \u2192 GPU**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the packages and make sure numpy is in a consistent state.\n"
    ]
   },
   {
@@ -17,37 +38,117 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Install mdopt and CuPy (the CuPy wheel matches Colab's CUDA 12 runtime).\n",
     "!pip -q install \"git+https://github.com/quicophy/mdopt.git\"\n",
+    "!pip -q install cupy-cuda12x\n",
     "\n",
-    "import time, numpy as np\n",
+    "# mdopt requires numpy>=2.3, so pip upgrades the numpy that Colab preloads at\n",
+    "# startup. Because the old numpy is already imported by the running kernel, the\n",
+    "# upgrade can leave a mix of new Python files and the old compiled extension,\n",
+    "# which shows up as \"ImportError: cannot import name '_slice' from\n",
+    "# numpy._core.umath\". Reinstalling numpy once, cleanly, repairs that.\n",
+    "!pip -q install --force-reinstall --no-cache-dir \"numpy>=2.3,<2.5\"\n",
+    "\n",
+    "# Verify in a *fresh* process: this kernel may still hold the stale numpy, but\n",
+    "# the benchmarks below run in subprocesses and so pick up the repaired one.\n",
+    "!python -c \"import numpy; print('numpy', numpy.__version__, 'imports cleanly')\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "Write the benchmark to a file so both runs execute exactly the same code.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile bench.py\n",
+    "\"\"\"MPS-MPO contraction benchmark. The backend is chosen by MDOPT_BACKEND.\"\"\"\n",
+    "\n",
+    "import os\n",
+    "import time\n",
+    "\n",
     "from tqdm import tqdm\n",
+    "\n",
     "from mdopt.mps.utils import create_simple_product_state\n",
-    "from mdopt.utils.utils import create_random_mpo, mpo_to_matrix\n",
+    "from mdopt.utils.utils import create_random_mpo\n",
     "from mdopt.contractor.contractor import mps_mpo_contract\n",
     "from mdopt.backend import array as A\n",
     "\n",
-    "print(\"Backend GPU flag:\", A.GPU)  # should be False\n",
+    "LABEL = os.environ.get(\"BENCH_LABEL\", A.backend_name().upper())\n",
     "\n",
-    "def bench(run_label=\"CPU\", num_sites=48, phys_dim=2, mpo_len=32, chi=256, reps=5):\n",
-    "    mps = create_simple_product_state(num_sites=num_sites, which=\"0\", phys_dim=phys_dim)\n",
+    "\n",
+    "def bench(num_sites=48, phys_dim=2, mpo_len=32, chi=256, reps=10):\n",
+    "    \"\"\"Time one MPS-MPO contraction, averaged over `reps` repetitions.\"\"\"\n",
+    "    mps = create_simple_product_state(\n",
+    "        num_sites=num_sites, which=\"0\", phys_dim=phys_dim\n",
+    "    )\n",
     "    mpo = create_random_mpo(\n",
     "        num_sites=mpo_len,\n",
-    "        bond_dimensions=[chi]*(mpo_len-1),\n",
+    "        bond_dimensions=[chi] * (mpo_len - 1),\n",
     "        phys_dim=phys_dim,\n",
     "        which=\"uniform\",\n",
     "    )\n",
-    "    start_site = 0\n",
-    "    # warm-up\n",
-    "    _ = mps_mpo_contract(mps.copy(), mpo, start_site=start_site, renormalise=False)\n",
+    "\n",
+    "    # Warm-up, so one-off allocation and CUDA kernel compilation are not timed.\n",
+    "    mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
     "    A.synchronize()\n",
+    "\n",
     "    t0 = time.perf_counter()\n",
     "    for _ in tqdm(range(reps)):\n",
-    "        _ = mps_mpo_contract(mps.copy(), mpo, start_site=start_site, renormalise=False)\n",
+    "        mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
     "    A.synchronize()\n",
     "    t1 = time.perf_counter()\n",
-    "    print(f\"{run_label}: {((t1 - t0)/reps):.4f} s per run\")\n",
     "\n",
-    "cpu_time = bench(\"CPU\", num_sites=48, mpo_len=32, chi=256, reps=10)"
+    "    seconds = (t1 - t0) / reps\n",
+    "    print(f\"{LABEL}: {seconds:.4f} s per run\")\n",
+    "    return seconds\n",
+    "\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    print(f\"Backend: {A.backend_name()} | GPU flag: {A.GPU}\")\n",
+    "    bench()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "source": [
+    "## CPU baseline\n",
+    "\n",
+    "Run with the numpy backend.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "!MDOPT_BACKEND=numpy BENCH_LABEL=CPU {sys.executable} bench.py\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "source": [
+    "## GPU run\n",
+    "\n",
+    "Same code, same parameters, with the CuPy backend.\n",
+    "If `GPU flag` prints `False`, the runtime has no GPU and `mdopt` silently fell\n",
+    "back to numpy \u2014 switch the runtime to GPU and re-run this cell.\n"
    ]
   },
   {
@@ -57,43 +158,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# In Colab, don't forget to switch the runtime to GPU before running the next block\n",
-    "\n",
     "!nvidia-smi\n",
-    "!pip -q install cupy-cuda12x\n",
-    "!pip -q install \"git+https://github.com/quicophy/mdopt.git\"\n",
     "\n",
-    "%env MDOPT_BACKEND=cupy\n",
-    "\n",
-    "import time, numpy as np\n",
-    "from tqdm import tqdm\n",
-    "from mdopt.mps.utils import create_simple_product_state\n",
-    "from mdopt.utils.utils import create_random_mpo\n",
-    "from mdopt.contractor.contractor import mps_mpo_contract\n",
-    "from mdopt.backend import array as A\n",
-    "\n",
-    "print(\"Backend GPU flag:\", A.GPU)  # should be True\n",
-    "\n",
-    "def bench(run_label=\"GPU\", num_sites=48, phys_dim=2, mpo_len=32, chi=256, reps=5):\n",
-    "    mps = create_simple_product_state(num_sites=num_sites, which=\"0\", phys_dim=phys_dim)\n",
-    "    mpo = create_random_mpo(\n",
-    "        num_sites=mpo_len,\n",
-    "        bond_dimensions=[chi]*(mpo_len-1),\n",
-    "        phys_dim=phys_dim,\n",
-    "        which=\"uniform\",\n",
-    "    )\n",
-    "    start_site = 0\n",
-    "    # warm-up\n",
-    "    _ = mps_mpo_contract(mps.copy(), mpo, start_site=start_site, renormalise=False)\n",
-    "    A.synchronize()\n",
-    "    t0 = time.perf_counter()\n",
-    "    for _ in tqdm(range(reps)):\n",
-    "        _ = mps_mpo_contract(mps.copy(), mpo, start_site=start_site, renormalise=False)\n",
-    "    A.synchronize()\n",
-    "    t1 = time.perf_counter()\n",
-    "    print(f\"{run_label}: {((t1 - t0)/reps):.4f} s per run\")\n",
-    "\n",
-    "cpu_time = bench(\"GPU\", num_sites=48, mpo_len=32, chi=256, reps=10)"
+    "!MDOPT_BACKEND=cupy BENCH_LABEL=GPU {sys.executable} bench.py\n"
    ]
   }
  ],

--- a/examples/misc/gpu_example.ipynb
+++ b/examples/misc/gpu_example.ipynb
@@ -238,7 +238,7 @@
         "## GPU run\n",
         "\n",
         "Same code, same parameters, with the CuPy backend.\n",
-        "If `GPU flag` prints `False`, the runtime has no GPU and `mdopt` silently fell\n",
+        "If `GPU flag` prints `False`, the runtime has no GPU and `mdopt` warned and fell\n",
         "back to numpy — switch the runtime to GPU and re-run this cell.\n"
       ]
     },

--- a/examples/misc/gpu_example.ipynb
+++ b/examples/misc/gpu_example.ipynb
@@ -141,9 +141,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "\n",
-    "!MDOPT_BACKEND=numpy BENCH_LABEL=CPU {sys.executable} bench.py\n"
+    "# `python` is the same interpreter the notebook runs on; the setup cell above\n",
+    "# already used it. Each benchmark runs as a separate process so that\n",
+    "# MDOPT_BACKEND is read fresh on import.\n",
+    "!MDOPT_BACKEND=numpy BENCH_LABEL=CPU python bench.py\n"
    ]
   },
   {
@@ -167,7 +168,7 @@
    "source": [
     "!nvidia-smi\n",
     "\n",
-    "!MDOPT_BACKEND=cupy BENCH_LABEL=GPU {sys.executable} bench.py\n"
+    "!MDOPT_BACKEND=cupy BENCH_LABEL=GPU python bench.py\n"
    ]
   }
  ],

--- a/examples/misc/gpu_example.ipynb
+++ b/examples/misc/gpu_example.ipynb
@@ -1,188 +1,311 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "6282ba43",
-   "metadata": {},
-   "source": [
-    "# GPU Backend Example\n",
-    "\n",
-    "This example shows how to run `mdopt` on a GPU through [CuPy](https://cupy.dev/),\n",
-    "and compares the cost of the same MPS-MPO contraction on CPU and GPU.\n",
-    "\n",
-    "`mdopt` picks its array backend from the `MDOPT_BACKEND` environment variable,\n",
-    "and it does so **once, when `mdopt.backend.array` is first imported**. A single\n",
-    "Python process therefore cannot switch backends after the fact. To keep this\n",
-    "notebook runnable top to bottom, each benchmark is launched in its own\n",
-    "subprocess with the appropriate `MDOPT_BACKEND` value, so no kernel restarts\n",
-    "are needed and both results end up in one run.\n",
-    "\n",
-    "To run this on Colab, first switch the runtime to a GPU:\n",
-    "**Runtime \u2192 Change runtime type \u2192 Hardware accelerator \u2192 GPU**.\n"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "6282ba43",
+      "metadata": {
+        "id": "6282ba43"
+      },
+      "source": [
+        "# GPU Backend Example\n",
+        "\n",
+        "This example shows how to run `mdopt` on a GPU through [CuPy](https://cupy.dev/),\n",
+        "and compares the cost of the same MPS-MPO contraction on CPU and GPU.\n",
+        "\n",
+        "`mdopt` picks its array backend from the `MDOPT_BACKEND` environment variable,\n",
+        "and it does so **once, when `mdopt.backend.array` is first imported**. A single\n",
+        "Python process therefore cannot switch backends after the fact. To keep this\n",
+        "notebook runnable top to bottom, each benchmark is launched in its own\n",
+        "subprocess with the appropriate `MDOPT_BACKEND` value, so no kernel restarts\n",
+        "are needed and both results end up in one run.\n",
+        "\n",
+        "To run this on Colab, first switch the runtime to a GPU:\n",
+        "**Runtime → Change runtime type → Hardware accelerator → GPU**.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a1b2c3d4",
+      "metadata": {
+        "id": "a1b2c3d4"
+      },
+      "source": [
+        "## Setup\n",
+        "\n",
+        "Install the packages and make sure numpy is in a consistent state.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "dac5ce7b",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "dac5ce7b",
+        "outputId": "7fe19d24-0427-4421-88a6-92d3405c3829"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m177.3/177.3 kB\u001b[0m \u001b[31m7.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.3/8.3 MB\u001b[0m \u001b[31m14.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m16.6/16.6 MB\u001b[0m \u001b[31m84.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m148.0/148.0 kB\u001b[0m \u001b[31m9.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.3/1.3 MB\u001b[0m \u001b[31m15.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m135.0/135.0 kB\u001b[0m \u001b[31m11.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m45.5/45.5 kB\u001b[0m \u001b[31m4.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.2/4.2 MB\u001b[0m \u001b[31m81.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m625.9/625.9 kB\u001b[0m \u001b[31m39.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.3/5.3 MB\u001b[0m \u001b[31m89.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.9/3.9 MB\u001b[0m \u001b[31m94.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m59.9/59.9 MB\u001b[0m \u001b[31m10.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Building wheel for mdopt (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Building wheel for sinter (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "cuml-cu12 26.2.0 requires numba<0.62.0,>=0.60.0, but you have numba 0.67.0 which is incompatible.\n",
+            "pytensor 2.38.3 requires numba<=0.65.1,>=0.58, but you have numba 0.67.0 which is incompatible.\n",
+            "cudf-cu12 26.2.1 requires numba<0.62.0,>=0.60.0, but you have numba 0.67.0 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m16.6/16.6 MB\u001b[0m \u001b[31m198.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "cuml-cu12 26.2.0 requires numba<0.62.0,>=0.60.0, but you have numba 0.67.0 which is incompatible.\n",
+            "pytensor 2.38.3 requires numba<=0.65.1,>=0.58, but you have numba 0.67.0 which is incompatible.\n",
+            "cudf-cu12 26.2.1 requires numba<0.62.0,>=0.60.0, but you have numba 0.67.0 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[0mnumpy 2.4.6 imports cleanly\n",
+            "Tesla T4, 580.82.07\n",
+            "cupy 14.0.1 | CUDA runtime 12090\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Install mdopt. Colab's GPU runtimes already ship CuPy, pinned to a version\n",
+        "# whose bundled CUDA runtime matches the driver on the VM. Reinstalling it pulls\n",
+        "# the latest wheel, which can need a newer driver than the VM has and then fails\n",
+        "# with \"cudaErrorInsufficientDriver\" once a CUDA call is made -- so we\n",
+        "# deliberately leave CuPy alone here.\n",
+        "!pip -q install \"git+https://github.com/quicophy/mdopt.git\"\n",
+        "\n",
+        "# mdopt requires numpy>=2.3, so pip upgrades the numpy that Colab preloads at\n",
+        "# startup. Because the old numpy is already imported by the running kernel, the\n",
+        "# upgrade can leave a mix of new Python files and the old compiled extension,\n",
+        "# which shows up as \"ImportError: cannot import name '_slice' from\n",
+        "# numpy._core.umath\". Reinstalling numpy once, cleanly, repairs that.\n",
+        "!pip -q install --force-reinstall --no-cache-dir \"numpy>=2.3,<2.5\"\n",
+        "\n",
+        "# Report the environment from *fresh* processes: this kernel may still hold the\n",
+        "# stale numpy, but the benchmarks below run in subprocesses and so pick up the\n",
+        "# repaired one. The driver and CUDA runtime versions are printed together, since\n",
+        "# a GPU run needs the driver to be new enough for the runtime CuPy was built for.\n",
+        "!python -c \"import numpy; print('numpy', numpy.__version__, 'imports cleanly')\"\n",
+        "!nvidia-smi --query-gpu=name,driver_version --format=csv,noheader || echo \"no GPU on this runtime\"\n",
+        "!python -c \"import cupy; print('cupy', cupy.__version__, '| CUDA runtime', cupy.cuda.runtime.runtimeGetVersion())\" || echo \"CuPy unavailable\"\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b2c3d4e5",
+      "metadata": {
+        "id": "b2c3d4e5"
+      },
+      "source": [
+        "Write the benchmark to a file so both runs execute exactly the same code.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "c3d4e5f6",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "c3d4e5f6",
+        "outputId": "6148bfc7-4234-4268-de26-c057504690be"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Writing bench.py\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%writefile bench.py\n",
+        "\"\"\"MPS-MPO contraction benchmark. The backend is chosen by MDOPT_BACKEND.\"\"\"\n",
+        "\n",
+        "import os\n",
+        "import time\n",
+        "\n",
+        "from tqdm import tqdm\n",
+        "\n",
+        "from mdopt.mps.utils import create_simple_product_state\n",
+        "from mdopt.utils.utils import create_random_mpo\n",
+        "from mdopt.contractor.contractor import mps_mpo_contract\n",
+        "from mdopt.backend import array as A\n",
+        "\n",
+        "LABEL = os.environ.get(\"BENCH_LABEL\", A.backend_name().upper())\n",
+        "\n",
+        "\n",
+        "def bench(num_sites=48, phys_dim=2, mpo_len=32, chi=256, reps=10):\n",
+        "    \"\"\"Time one MPS-MPO contraction, averaged over `reps` repetitions.\"\"\"\n",
+        "    mps = create_simple_product_state(\n",
+        "        num_sites=num_sites, which=\"0\", phys_dim=phys_dim\n",
+        "    )\n",
+        "    mpo = create_random_mpo(\n",
+        "        num_sites=mpo_len,\n",
+        "        bond_dimensions=[chi] * (mpo_len - 1),\n",
+        "        phys_dim=phys_dim,\n",
+        "        which=\"uniform\",\n",
+        "    )\n",
+        "\n",
+        "    # Warm-up, so one-off allocation and CUDA kernel compilation are not timed.\n",
+        "    mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
+        "    A.synchronize()\n",
+        "\n",
+        "    t0 = time.perf_counter()\n",
+        "    for _ in tqdm(range(reps)):\n",
+        "        mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
+        "    A.synchronize()\n",
+        "    t1 = time.perf_counter()\n",
+        "\n",
+        "    seconds = (t1 - t0) / reps\n",
+        "    print(f\"{LABEL}: {seconds:.4f} s per run\")\n",
+        "    return seconds\n",
+        "\n",
+        "\n",
+        "if __name__ == \"__main__\":\n",
+        "    print(f\"Backend: {A.backend_name()} | GPU flag: {A.GPU}\")\n",
+        "    bench()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d4e5f6a7",
+      "metadata": {
+        "id": "d4e5f6a7"
+      },
+      "source": [
+        "## CPU baseline\n",
+        "\n",
+        "Run with the numpy backend.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "e5f6a7b8",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "e5f6a7b8",
+        "outputId": "5ac972eb-451e-403f-b3a4-31f82129876d"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Backend: numpy | GPU flag: False\n",
+            "100% 10/10 [02:50<00:00, 17.05s/it]\n",
+            "CPU: 17.0527 s per run\n"
+          ]
+        }
+      ],
+      "source": [
+        "# `python` is the same interpreter the notebook runs on; the setup cell above\n",
+        "# already used it. Each benchmark runs as a separate process so that\n",
+        "# MDOPT_BACKEND is read fresh on import.\n",
+        "!MDOPT_BACKEND=numpy BENCH_LABEL=CPU python bench.py\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f6a7b8c9",
+      "metadata": {
+        "id": "f6a7b8c9"
+      },
+      "source": [
+        "## GPU run\n",
+        "\n",
+        "Same code, same parameters, with the CuPy backend.\n",
+        "If `GPU flag` prints `False`, the runtime has no GPU and `mdopt` silently fell\n",
+        "back to numpy — switch the runtime to GPU and re-run this cell.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "908d389e",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "908d389e",
+        "outputId": "49db5302-64d6-45df-c286-c653b066892f"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Sat Aug 22 21:00:20 2026       \n",
+            "+-----------------------------------------------------------------------------------------+\n",
+            "| NVIDIA-SMI 580.82.07              Driver Version: 580.82.07      CUDA Version: 13.0     |\n",
+            "+-----------------------------------------+------------------------+----------------------+\n",
+            "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
+            "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
+            "|                                         |                        |               MIG M. |\n",
+            "|=========================================+========================+======================|\n",
+            "|   0  Tesla T4                       Off |   00000000:00:04.0 Off |                    0 |\n",
+            "| N/A   48C    P8             12W /   70W |       0MiB /  15360MiB |      0%      Default |\n",
+            "|                                         |                        |                  N/A |\n",
+            "+-----------------------------------------+------------------------+----------------------+\n",
+            "\n",
+            "+-----------------------------------------------------------------------------------------+\n",
+            "| Processes:                                                                              |\n",
+            "|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |\n",
+            "|        ID   ID                                                               Usage      |\n",
+            "|=========================================================================================|\n",
+            "|  No running processes found                                                             |\n",
+            "+-----------------------------------------------------------------------------------------+\n",
+            "Backend: cupy | GPU flag: True\n",
+            "100% 10/10 [00:04<00:00,  2.04it/s]\n",
+            "GPU: 0.4911 s per run\n"
+          ]
+        }
+      ],
+      "source": [
+        "!nvidia-smi\n",
+        "\n",
+        "!MDOPT_BACKEND=cupy BENCH_LABEL=GPU python bench.py\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.16"
+    },
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4"
+    },
+    "accelerator": "GPU"
   },
-  {
-   "cell_type": "markdown",
-   "id": "a1b2c3d4",
-   "metadata": {},
-   "source": [
-    "## Setup\n",
-    "\n",
-    "Install the packages and make sure numpy is in a consistent state.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dac5ce7b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install mdopt. Colab's GPU runtimes already ship CuPy, pinned to a version\n",
-    "# whose bundled CUDA runtime matches the driver on the VM. Reinstalling it pulls\n",
-    "# the latest wheel, which can need a newer driver than the VM has and then fails\n",
-    "# with \"cudaErrorInsufficientDriver\" once a CUDA call is made -- so we\n",
-    "# deliberately leave CuPy alone here.\n",
-    "!pip -q install \"git+https://github.com/quicophy/mdopt.git\"\n",
-    "\n",
-    "# mdopt requires numpy>=2.3, so pip upgrades the numpy that Colab preloads at\n",
-    "# startup. Because the old numpy is already imported by the running kernel, the\n",
-    "# upgrade can leave a mix of new Python files and the old compiled extension,\n",
-    "# which shows up as \"ImportError: cannot import name '_slice' from\n",
-    "# numpy._core.umath\". Reinstalling numpy once, cleanly, repairs that.\n",
-    "!pip -q install --force-reinstall --no-cache-dir \"numpy>=2.3,<2.5\"\n",
-    "\n",
-    "# Report the environment from *fresh* processes: this kernel may still hold the\n",
-    "# stale numpy, but the benchmarks below run in subprocesses and so pick up the\n",
-    "# repaired one. The driver and CUDA runtime versions are printed together, since\n",
-    "# a GPU run needs the driver to be new enough for the runtime CuPy was built for.\n",
-    "!python -c \"import numpy; print('numpy', numpy.__version__, 'imports cleanly')\"\n",
-    "!nvidia-smi --query-gpu=name,driver_version --format=csv,noheader || echo \"no GPU on this runtime\"\n",
-    "!python -c \"import cupy; print('cupy', cupy.__version__, '| CUDA runtime', cupy.cuda.runtime.runtimeGetVersion())\" || echo \"CuPy unavailable\"\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b2c3d4e5",
-   "metadata": {},
-   "source": [
-    "Write the benchmark to a file so both runs execute exactly the same code.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c3d4e5f6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile bench.py\n",
-    "\"\"\"MPS-MPO contraction benchmark. The backend is chosen by MDOPT_BACKEND.\"\"\"\n",
-    "\n",
-    "import os\n",
-    "import time\n",
-    "\n",
-    "from tqdm import tqdm\n",
-    "\n",
-    "from mdopt.mps.utils import create_simple_product_state\n",
-    "from mdopt.utils.utils import create_random_mpo\n",
-    "from mdopt.contractor.contractor import mps_mpo_contract\n",
-    "from mdopt.backend import array as A\n",
-    "\n",
-    "LABEL = os.environ.get(\"BENCH_LABEL\", A.backend_name().upper())\n",
-    "\n",
-    "\n",
-    "def bench(num_sites=48, phys_dim=2, mpo_len=32, chi=256, reps=10):\n",
-    "    \"\"\"Time one MPS-MPO contraction, averaged over `reps` repetitions.\"\"\"\n",
-    "    mps = create_simple_product_state(\n",
-    "        num_sites=num_sites, which=\"0\", phys_dim=phys_dim\n",
-    "    )\n",
-    "    mpo = create_random_mpo(\n",
-    "        num_sites=mpo_len,\n",
-    "        bond_dimensions=[chi] * (mpo_len - 1),\n",
-    "        phys_dim=phys_dim,\n",
-    "        which=\"uniform\",\n",
-    "    )\n",
-    "\n",
-    "    # Warm-up, so one-off allocation and CUDA kernel compilation are not timed.\n",
-    "    mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
-    "    A.synchronize()\n",
-    "\n",
-    "    t0 = time.perf_counter()\n",
-    "    for _ in tqdm(range(reps)):\n",
-    "        mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
-    "    A.synchronize()\n",
-    "    t1 = time.perf_counter()\n",
-    "\n",
-    "    seconds = (t1 - t0) / reps\n",
-    "    print(f\"{LABEL}: {seconds:.4f} s per run\")\n",
-    "    return seconds\n",
-    "\n",
-    "\n",
-    "if __name__ == \"__main__\":\n",
-    "    print(f\"Backend: {A.backend_name()} | GPU flag: {A.GPU}\")\n",
-    "    bench()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d4e5f6a7",
-   "metadata": {},
-   "source": [
-    "## CPU baseline\n",
-    "\n",
-    "Run with the numpy backend.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e5f6a7b8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# `python` is the same interpreter the notebook runs on; the setup cell above\n",
-    "# already used it. Each benchmark runs as a separate process so that\n",
-    "# MDOPT_BACKEND is read fresh on import.\n",
-    "!MDOPT_BACKEND=numpy BENCH_LABEL=CPU python bench.py\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f6a7b8c9",
-   "metadata": {},
-   "source": [
-    "## GPU run\n",
-    "\n",
-    "Same code, same parameters, with the CuPy backend.\n",
-    "If `GPU flag` prints `False`, the runtime has no GPU and `mdopt` silently fell\n",
-    "back to numpy \u2014 switch the runtime to GPU and re-run this cell.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "908d389e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!nvidia-smi\n",
-    "\n",
-    "!MDOPT_BACKEND=cupy BENCH_LABEL=GPU python bench.py\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "mdopt-ZdbamFdU-py3.10",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.10.16"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/examples/misc/gpu_example.ipynb
+++ b/examples/misc/gpu_example.ipynb
@@ -38,9 +38,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install mdopt and CuPy (the CuPy wheel matches Colab's CUDA 12 runtime).\n",
+    "# Install mdopt. Colab's GPU runtimes already ship CuPy, pinned to a version\n",
+    "# whose bundled CUDA runtime matches the driver on the VM. Reinstalling it pulls\n",
+    "# the latest wheel, which can need a newer driver than the VM has and then fails\n",
+    "# with \"cudaErrorInsufficientDriver\" once a CUDA call is made -- so we\n",
+    "# deliberately leave CuPy alone here.\n",
     "!pip -q install \"git+https://github.com/quicophy/mdopt.git\"\n",
-    "!pip -q install cupy-cuda12x\n",
     "\n",
     "# mdopt requires numpy>=2.3, so pip upgrades the numpy that Colab preloads at\n",
     "# startup. Because the old numpy is already imported by the running kernel, the\n",
@@ -49,9 +52,13 @@
     "# numpy._core.umath\". Reinstalling numpy once, cleanly, repairs that.\n",
     "!pip -q install --force-reinstall --no-cache-dir \"numpy>=2.3,<2.5\"\n",
     "\n",
-    "# Verify in a *fresh* process: this kernel may still hold the stale numpy, but\n",
-    "# the benchmarks below run in subprocesses and so pick up the repaired one.\n",
-    "!python -c \"import numpy; print('numpy', numpy.__version__, 'imports cleanly')\"\n"
+    "# Report the environment from *fresh* processes: this kernel may still hold the\n",
+    "# stale numpy, but the benchmarks below run in subprocesses and so pick up the\n",
+    "# repaired one. The driver and CUDA runtime versions are printed together, since\n",
+    "# a GPU run needs the driver to be new enough for the runtime CuPy was built for.\n",
+    "!python -c \"import numpy; print('numpy', numpy.__version__, 'imports cleanly')\"\n",
+    "!nvidia-smi --query-gpu=name,driver_version --format=csv,noheader || echo \"no GPU on this runtime\"\n",
+    "!python -c \"import cupy; print('cupy', cupy.__version__, '| CUDA runtime', cupy.cuda.runtime.runtimeGetVersion())\" || echo \"CuPy unavailable\"\n"
    ]
   },
   {

--- a/examples/misc/gpu_example.ipynb
+++ b/examples/misc/gpu_example.ipynb
@@ -5,6 +5,8 @@
    "id": "6282ba43",
    "metadata": {},
    "source": [
+    "# GPU Backend Example\n",
+    "\n",
     "This example is intended to show how to use CuPy to run mdopt on GPU. It has two blocks of code which are to be run in Colab to show the performance difference between CPU and GPU."
    ]
   },

--- a/examples/misc/gpu_example.ipynb
+++ b/examples/misc/gpu_example.ipynb
@@ -7,7 +7,28 @@
    "source": [
     "# GPU Backend Example\n",
     "\n",
-    "This example is intended to show how to use CuPy to run mdopt on GPU. It has two blocks of code which are to be run in Colab to show the performance difference between CPU and GPU."
+    "This example shows how to run `mdopt` on a GPU through [CuPy](https://cupy.dev/),\n",
+    "and compares the cost of the same MPS-MPO contraction on CPU and GPU.\n",
+    "\n",
+    "`mdopt` picks its array backend from the `MDOPT_BACKEND` environment variable,\n",
+    "and it does so **once, when `mdopt.backend.array` is first imported**. A single\n",
+    "Python process therefore cannot switch backends after the fact. To keep this\n",
+    "notebook runnable top to bottom, each benchmark is launched in its own\n",
+    "subprocess with the appropriate `MDOPT_BACKEND` value, so no kernel restarts\n",
+    "are needed and both results end up in one run.\n",
+    "\n",
+    "To run this on Colab, first switch the runtime to a GPU:\n",
+    "**Runtime \u2192 Change runtime type \u2192 Hardware accelerator \u2192 GPU**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the packages and make sure numpy is in a consistent state.\n"
    ]
   },
   {
@@ -17,37 +38,117 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Install mdopt and CuPy (the CuPy wheel matches Colab's CUDA 12 runtime).\n",
     "!pip -q install \"git+https://github.com/quicophy/mdopt.git\"\n",
+    "!pip -q install cupy-cuda12x\n",
     "\n",
-    "import time, numpy as np\n",
+    "# mdopt requires numpy>=2.3, so pip upgrades the numpy that Colab preloads at\n",
+    "# startup. Because the old numpy is already imported by the running kernel, the\n",
+    "# upgrade can leave a mix of new Python files and the old compiled extension,\n",
+    "# which shows up as \"ImportError: cannot import name '_slice' from\n",
+    "# numpy._core.umath\". Reinstalling numpy once, cleanly, repairs that.\n",
+    "!pip -q install --force-reinstall --no-cache-dir \"numpy>=2.3,<2.5\"\n",
+    "\n",
+    "# Verify in a *fresh* process: this kernel may still hold the stale numpy, but\n",
+    "# the benchmarks below run in subprocesses and so pick up the repaired one.\n",
+    "!python -c \"import numpy; print('numpy', numpy.__version__, 'imports cleanly')\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "Write the benchmark to a file so both runs execute exactly the same code.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile bench.py\n",
+    "\"\"\"MPS-MPO contraction benchmark. The backend is chosen by MDOPT_BACKEND.\"\"\"\n",
+    "\n",
+    "import os\n",
+    "import time\n",
+    "\n",
     "from tqdm import tqdm\n",
+    "\n",
     "from mdopt.mps.utils import create_simple_product_state\n",
-    "from mdopt.utils.utils import create_random_mpo, mpo_to_matrix\n",
+    "from mdopt.utils.utils import create_random_mpo\n",
     "from mdopt.contractor.contractor import mps_mpo_contract\n",
     "from mdopt.backend import array as A\n",
     "\n",
-    "print(\"Backend GPU flag:\", A.GPU)  # should be False\n",
+    "LABEL = os.environ.get(\"BENCH_LABEL\", A.backend_name().upper())\n",
     "\n",
-    "def bench(run_label=\"CPU\", num_sites=48, phys_dim=2, mpo_len=32, chi=256, reps=5):\n",
-    "    mps = create_simple_product_state(num_sites=num_sites, which=\"0\", phys_dim=phys_dim)\n",
+    "\n",
+    "def bench(num_sites=48, phys_dim=2, mpo_len=32, chi=256, reps=10):\n",
+    "    \"\"\"Time one MPS-MPO contraction, averaged over `reps` repetitions.\"\"\"\n",
+    "    mps = create_simple_product_state(\n",
+    "        num_sites=num_sites, which=\"0\", phys_dim=phys_dim\n",
+    "    )\n",
     "    mpo = create_random_mpo(\n",
     "        num_sites=mpo_len,\n",
-    "        bond_dimensions=[chi]*(mpo_len-1),\n",
+    "        bond_dimensions=[chi] * (mpo_len - 1),\n",
     "        phys_dim=phys_dim,\n",
     "        which=\"uniform\",\n",
     "    )\n",
-    "    start_site = 0\n",
-    "    # warm-up\n",
-    "    _ = mps_mpo_contract(mps.copy(), mpo, start_site=start_site, renormalise=False)\n",
+    "\n",
+    "    # Warm-up, so one-off allocation and CUDA kernel compilation are not timed.\n",
+    "    mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
     "    A.synchronize()\n",
+    "\n",
     "    t0 = time.perf_counter()\n",
     "    for _ in tqdm(range(reps)):\n",
-    "        _ = mps_mpo_contract(mps.copy(), mpo, start_site=start_site, renormalise=False)\n",
+    "        mps_mpo_contract(mps.copy(), mpo, start_site=0, renormalise=False)\n",
     "    A.synchronize()\n",
     "    t1 = time.perf_counter()\n",
-    "    print(f\"{run_label}: {((t1 - t0)/reps):.4f} s per run\")\n",
     "\n",
-    "cpu_time = bench(\"CPU\", num_sites=48, mpo_len=32, chi=256, reps=10)"
+    "    seconds = (t1 - t0) / reps\n",
+    "    print(f\"{LABEL}: {seconds:.4f} s per run\")\n",
+    "    return seconds\n",
+    "\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    print(f\"Backend: {A.backend_name()} | GPU flag: {A.GPU}\")\n",
+    "    bench()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "source": [
+    "## CPU baseline\n",
+    "\n",
+    "Run with the numpy backend.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "!MDOPT_BACKEND=numpy BENCH_LABEL=CPU {sys.executable} bench.py\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "source": [
+    "## GPU run\n",
+    "\n",
+    "Same code, same parameters, with the CuPy backend.\n",
+    "If `GPU flag` prints `False`, the runtime has no GPU and `mdopt` silently fell\n",
+    "back to numpy \u2014 switch the runtime to GPU and re-run this cell.\n"
    ]
   },
   {
@@ -57,43 +158,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# In Colab, don't forget to switch the runtime to GPU before running the next block\n",
-    "\n",
     "!nvidia-smi\n",
-    "!pip -q install cupy-cuda12x\n",
-    "!pip -q install \"git+https://github.com/quicophy/mdopt.git\"\n",
     "\n",
-    "%env MDOPT_BACKEND=cupy\n",
-    "\n",
-    "import time, numpy as np\n",
-    "from tqdm import tqdm\n",
-    "from mdopt.mps.utils import create_simple_product_state\n",
-    "from mdopt.utils.utils import create_random_mpo\n",
-    "from mdopt.contractor.contractor import mps_mpo_contract\n",
-    "from mdopt.backend import array as A\n",
-    "\n",
-    "print(\"Backend GPU flag:\", A.GPU)  # should be True\n",
-    "\n",
-    "def bench(run_label=\"GPU\", num_sites=48, phys_dim=2, mpo_len=32, chi=256, reps=5):\n",
-    "    mps = create_simple_product_state(num_sites=num_sites, which=\"0\", phys_dim=phys_dim)\n",
-    "    mpo = create_random_mpo(\n",
-    "        num_sites=mpo_len,\n",
-    "        bond_dimensions=[chi]*(mpo_len-1),\n",
-    "        phys_dim=phys_dim,\n",
-    "        which=\"uniform\",\n",
-    "    )\n",
-    "    start_site = 0\n",
-    "    # warm-up\n",
-    "    _ = mps_mpo_contract(mps.copy(), mpo, start_site=start_site, renormalise=False)\n",
-    "    A.synchronize()\n",
-    "    t0 = time.perf_counter()\n",
-    "    for _ in tqdm(range(reps)):\n",
-    "        _ = mps_mpo_contract(mps.copy(), mpo, start_site=start_site, renormalise=False)\n",
-    "    A.synchronize()\n",
-    "    t1 = time.perf_counter()\n",
-    "    print(f\"{run_label}: {((t1 - t0)/reps):.4f} s per run\")\n",
-    "\n",
-    "cpu_time = bench(\"GPU\", num_sites=48, mpo_len=32, chi=256, reps=10)"
+    "!MDOPT_BACKEND=cupy BENCH_LABEL=GPU {sys.executable} bench.py\n"
    ]
   }
  ],

--- a/mdopt/backend/array.py
+++ b/mdopt/backend/array.py
@@ -4,6 +4,7 @@ Array backend selection and helpers.
 
 import os
 import importlib
+import warnings
 
 # ----------------------------------------------------------------------
 # Backend selection: default to NumPy; allow CUPY if available.
@@ -11,13 +12,45 @@ import importlib
 _BACKEND_ENV = os.getenv("MDOPT_BACKEND", "numpy").lower()
 
 
+def _cuda_device_available(cupy) -> bool:
+    """
+    Whether CuPy can actually reach a CUDA device.
+
+    Importing CuPy succeeds on machines with no GPU or an outdated driver --
+    the failure only surfaces on the first device call. Probing here keeps
+    :data:`GPU` meaning "GPU usable" rather than "CuPy importable", so we fall
+    back to NumPy instead of raising from deep inside a contraction.
+    """
+    try:
+        return cupy.cuda.runtime.getDeviceCount() > 0
+    except Exception:  # pylint: disable=broad-except
+        # Any driver/runtime problem (e.g. cudaErrorInsufficientDriver) means
+        # there is no device we can use.
+        return False
+
+
 def _load_backend():
     if _BACKEND_ENV == "cupy":
         try:
-            return importlib.import_module("cupy")
+            cupy = importlib.import_module("cupy")
         except (ImportError, ModuleNotFoundError):
             # Graceful fallback on machines without CuPy (e.g., macOS)
-            pass
+            warnings.warn(
+                "MDOPT_BACKEND=cupy was requested but CuPy is not installed; "
+                "falling back to the NumPy backend.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        else:
+            if _cuda_device_available(cupy):
+                return cupy
+            warnings.warn(
+                "MDOPT_BACKEND=cupy was requested and CuPy imported, but no "
+                "usable CUDA device was found; falling back to the NumPy "
+                "backend.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
     return importlib.import_module("numpy")
 
 

--- a/tests/backend/test_array.py
+++ b/tests/backend/test_array.py
@@ -1,0 +1,88 @@
+"""Tests for backend selection in :mod:`mdopt.backend.array`."""
+
+import importlib
+import sys
+import types
+import warnings
+
+import pytest
+
+
+def _reload_backend(monkeypatch, backend_env, fake_cupy):
+    """Import a fresh copy of the backend module under a controlled environment."""
+    for name in [n for n in sys.modules if n.startswith("mdopt")]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.delitem(sys.modules, "cupy", raising=False)
+
+    if fake_cupy is not None:
+        monkeypatch.setitem(sys.modules, "cupy", fake_cupy)
+    if backend_env is None:
+        monkeypatch.delenv("MDOPT_BACKEND", raising=False)
+    else:
+        monkeypatch.setenv("MDOPT_BACKEND", backend_env)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        module = importlib.import_module("mdopt.backend.array")
+    return module, caught
+
+
+def _fake_cupy(num_devices=0, raises=False):
+    """A stand-in for CuPy that reports a given number of CUDA devices."""
+    module = types.ModuleType("cupy")
+
+    def get_device_count():
+        if raises:
+            raise RuntimeError("cudaErrorInsufficientDriver")
+        return num_devices
+
+    runtime = types.SimpleNamespace(getDeviceCount=get_device_count)
+    module.cuda = types.SimpleNamespace(runtime=runtime, Stream=object, Device=object)
+    module.asarray = lambda a: a
+    return module
+
+
+def test_defaults_to_numpy(monkeypatch):
+    """With no MDOPT_BACKEND set, NumPy is used and nothing is warned about."""
+    module, caught = _reload_backend(monkeypatch, None, None)
+    assert module.GPU is False
+    assert module.backend_name() == "numpy"
+    assert not caught
+
+
+def test_falls_back_when_cupy_missing(monkeypatch):
+    """Requesting CuPy without it installed warns and falls back to NumPy."""
+    module, caught = _reload_backend(monkeypatch, "cupy", None)
+    assert module.GPU is False
+    assert any("not installed" in str(w.message) for w in caught)
+
+
+def test_falls_back_when_no_cuda_device(monkeypatch):
+    """CuPy imports fine without a GPU, so the device count decides."""
+    module, caught = _reload_backend(monkeypatch, "cupy", _fake_cupy(num_devices=0))
+    assert module.GPU is False
+    assert module.backend_name() == "numpy"
+    assert any("no usable CUDA device" in str(w.message) for w in caught)
+
+
+def test_falls_back_when_driver_raises(monkeypatch):
+    """A driver too old to serve the runtime must not select the GPU backend."""
+    module, caught = _reload_backend(monkeypatch, "cupy", _fake_cupy(raises=True))
+    assert module.GPU is False
+    assert any("no usable CUDA device" in str(w.message) for w in caught)
+
+
+def test_uses_cupy_when_device_present(monkeypatch):
+    """A usable device must still select the CuPy backend, without warning."""
+    module, caught = _reload_backend(monkeypatch, "cupy", _fake_cupy(num_devices=1))
+    assert module.GPU is True
+    assert module.backend_name() == "cupy"
+    assert not caught
+
+
+def test_stream_is_a_context_manager_on_numpy(monkeypatch):
+    """The NumPy fallback still provides the stream()/synchronize() surface."""
+    module, _ = _reload_backend(monkeypatch, None, None)
+    with module.stream():
+        pass
+    module.synchronize()

--- a/tests/backend/test_array.py
+++ b/tests/backend/test_array.py
@@ -14,7 +14,9 @@ def _reload_backend(monkeypatch, backend_env, fake_cupy):
         monkeypatch.delitem(sys.modules, name, raising=False)
     monkeypatch.delitem(sys.modules, "cupy", raising=False)
 
-    if fake_cupy is not None:
+    if fake_cupy is None:
+        monkeypatch.setitem(sys.modules, "cupy", None)
+    else:
         monkeypatch.setitem(sys.modules, "cupy", fake_cupy)
     if backend_env is None:
         monkeypatch.delenv("MDOPT_BACKEND", raising=False)


### PR DESCRIPTION
The GPU example showed up as **"no title"** in the [examples list](https://mdopt.readthedocs.io/en/latest/examples.html) and its page carried no results. Fixing that surfaced a few reasons the notebook could not actually be run to produce them, plus one real library bug.

## The title

nbsphinx takes a notebook's toctree entry from its first H1 markdown heading, and this notebook opened with a plain paragraph — the only one of the eleven docs notebooks missing a heading. Read the Docs builds `docs/source/conf.py` directly rather than running `generate_docs.sh`, so the copy under `docs/source/notebooks/` is what gets published; both copies are now kept in step.

## Making it runnable on Colab

Three separate things stopped a Colab run:

- **numpy.** mdopt requires `numpy>=2.3`, so pip upgrades the numpy Colab preloads at kernel start. Because the old one is already imported, the upgrade leaves new Python files beside the old compiled extension and importing mdopt fails with `cannot import name '_slice' from numpy._core.umath` (`_slice` landed in numpy 2.3.0). A single clean reinstall repairs it.
- **Backend caching.** `mdopt.backend.array` reads `MDOPT_BACKEND` once at import, so one kernel cannot switch backends and the CPU and GPU cells could never both run in a session. Each benchmark now runs in its own subprocess, which also sidesteps any stale numpy left in the kernel. The notebook runs top to bottom in one pass.
- **CuPy.** Colab's GPU runtimes already ship CuPy pinned to match their driver. Installing `cupy-cuda12x` pulled a newer wheel whose CUDA runtime outran the driver, failing with `cudaErrorInsufficientDriver` on a machine with a working GPU. The notebook now leaves CuPy alone and prints the GPU, driver and CUDA runtime versions during setup.

The benchmark moved into a `bench.py` written by the notebook, so both runs execute identical code, and `bench()` returns the measured time instead of `None`.

## Backend bug

`_load_backend()` treated "CuPy imports" as "GPU available", catching only `ImportError`. But importing CuPy succeeds with no GPU or an outdated driver — the failure only appears on the first device call. `GPU` was therefore set to `True` and the crash landed far away inside `cupy.cuda.Stream` during a contraction.

Backend selection now probes the device count first, so `GPU` means "GPU usable" rather than "CuPy importable", and warns on fallback so an explicit `MDOPT_BACKEND=cupy` that silently runs on CPU is visible.

`tests/backend/test_array.py` is new — there was no coverage of this module at all. It uses a stub CuPy to cover all five selection paths, including that a present device still selects the GPU backend.

## Results

The notebook now carries outputs from a Colab T4 run, so the docs page shows numbers rather than bare code:

| backend | per contraction |
|---|---|
| NumPy | 17.0527 s |
| CuPy | 0.4911 s |

Roughly a 35x speedup, measured with CuPy 14.0.1 / CUDA runtime 12.9 against driver 580.82.07.

## Checks

- 90 tests pass (84 before, plus the 6 new backend tests)
- pylint, black and mypy clean; pre-commit passed on every commit
- Docs build succeeds and the examples list now reads **GPU Backend Example**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6mbxc9eJDQMVx7tjvYwud