### PR TITLE
Document the docs-sync PR contract

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -10,6 +10,10 @@ name: docs-sync
 # pull request" -- the first live run failed exactly there), delivers the
 # difference as a pull request on the docs-sync-bot branch.
 #
+# The full contract of the PR this opens -- triggers, rolling branch, stale
+# cleanup, the checks nudge -- is documented for contributors in
+# docs/source/notebook_pipeline.rst ("The sync PR").
+#
 # It copies; it does not execute. Notebook outputs come from a full-scale run
 # committed alongside the notebook -- see .github/workflows/notebooks.yml for
 # why CI cannot produce them itself.

--- a/docs/source/notebook_pipeline.rst
+++ b/docs/source/notebook_pipeline.rst
@@ -72,6 +72,37 @@ than a cluster campaign would give. The thesis figures come from the scripts in
 ``mdopt/examples/decoding/plotting/`` and their cluster datasets, not from these
 notebooks.
 
+The sync PR
+-----------
+
+The copy from ``examples/`` to ``docs/source/notebooks`` is delivered by a bot
+pull request from the rolling ``docs-sync-bot`` branch, because ``main`` is
+protected and rejects direct pushes. Its full contract:
+
+* **It opens (or updates) automatically** when a push to ``main`` touches
+  ``examples/**/*.ipynb``, ``examples/**/*.png``, ``docs/source/notebooks/**``,
+  ``generate_docs.sh`` or the workflow itself -- *and* the copy step finds real
+  drift. No drift, no PR.
+* **There is only ever one.** Consecutive drifts force-push the same branch,
+  updating the open PR in place.
+* **It cleans up after itself.** If the drift disappears (a notebook reverted,
+  or synchronised another way), the next run closes the stale PR and deletes
+  the branch, so outdated copies cannot be merged.
+* **Merging it does not loop.** The merge triggers a run that finds no drift
+  and exits without committing.
+* **Its checks need a nudge.** GitHub does not start CI for pull requests
+  opened with the default workflow token, so close and reopen the PR (or push
+  any commit to it) before a checks-gated merge. The PR body says so too.
+* **Manual dispatch:** ``gh workflow run docs-sync.yml --ref main`` runs the
+  sync on demand.
+
+One trap to know: GitHub honours CI-skip markers (such as ``[skip ci]``)
+anywhere in a commit message, and a squash merge concatenates every branch
+commit's title and body into one message. A commit that merely *quotes* such a
+marker therefore silences all workflows on the merge push -- including this
+sync. If a merge to ``main`` starts no workflows, check the squash message
+first, then dispatch the sync manually.
+
 What CI does instead
 --------------------
 


### PR DESCRIPTION
The sync-PR behaviour introduced in #532 was documented nowhere a contributor would look: the trigger conditions, the single rolling PR, the stale-PR self-cleanup, the close/reopen nudge its checks need, and the squash-message CI-skip trap all lived in workflow comments, the bot PR's generated body, or nowhere at all.

`docs/source/notebook_pipeline.rst` now carries the full contract in one section ("The sync PR"), and the workflow header points at it. Docs-only change; the page builds clean and the section renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6mbxc9eJDQMVx7tjvYwud