### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mdopt"
-version = "1.1.1"
+version = "2.0.0"
 description = "Discrete optimisation in the tensor-network (specifically, MPS-MPO) language."
 authors = [
     { name = "Aleksandr Berezutskii", email = "berezutskii.aleksandr@gmail.com" },


### PR DESCRIPTION
Version bump for the release cut from current `main`. Major bump because #535 (textbook symplectic semantics) changed decoder outputs and input conventions.

Release notes are drafted on the (draft) GitHub release; publishing it after this merges triggers the PyPI upload via `cd.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6mbxc9eJDQMVx7tjvYwud