### PR TITLE
Ignore mpmath >=1.4 in dependabot until sympy allows it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # sympy (every release up to 1.14.0) pins mpmath<1.4; drop this once
+      # a sympy release relaxes the cap.
+      - dependency-name: "mpmath"
+        versions: [">=1.4"]


### PR DESCRIPTION
Every sympy release up to the current 1.14.0 pins `mpmath<1.4,>=1.1.0`, so dependabot's recurring mpmath 1.4.x bump (#539, closed) can never install and only fails the docs build. This adds an ignore rule for `mpmath >=1.4` to be dropped once sympy relaxes the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6mbxc9eJDQMVx7tjvYwud