### PR TITLE
Warn when NumPy links Accelerate; document the OpenBLAS wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ Otherwise, you can clone the repository and use [poetry](https://python-poetry.o
 poetry install
 ```
 
+### A note on NumPy's BLAS on Apple silicon
+
+The macOS arm64 wheels of NumPy 2.x link Apple's Accelerate framework. On
+mdopt's matrices (rank-deficient, with singular values spanning many orders
+of magnitude) Accelerate's LAPACK corrupted memory: `numpy.linalg.qr` died
+with SIGBUS, `numpy.linalg.svd` tripped malloc's heap check, and a
+bivariate-bicycle decode returned wrong verdicts while every test passed.
+mdopt warns at import when it finds Accelerate behind NumPy. The OpenBLAS
+build of the same NumPy version is the `macosx_11_0_arm64` wheel:
+
+```bash
+pip download "numpy==$(python -c 'import numpy; print(numpy.__version__)')" \
+    --platform macosx_11_0_arm64 --only-binary=:all: --no-deps -d /tmp/numpy-openblas
+pip install --force-reinstall --no-deps /tmp/numpy-openblas/*.whl
+```
+
+Set `MDOPT_ALLOW_ACCELERATE=1` to silence the warning if you must keep
+Accelerate. Use `OMP_NUM_THREADS=1` (or `OPENBLAS_NUM_THREADS=1`) for the
+per-process BLAS of worker pools.
+
 ## Minimal example
 
 ```python

--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ mdopt's matrices (rank-deficient, with singular values spanning many orders
 of magnitude) Accelerate's LAPACK corrupted memory: `numpy.linalg.qr` died
 with SIGBUS, `numpy.linalg.svd` tripped malloc's heap check, and a
 bivariate-bicycle decode returned wrong verdicts while every test passed.
-mdopt warns at import when it finds Accelerate behind NumPy. The OpenBLAS
-build of the same NumPy version is the `macosx_11_0_arm64` wheel:
+The SciPy macOS wheels link Accelerate as well, and mdopt's SVD helpers
+call SciPy's LAPACK too. mdopt warns at import when it finds Accelerate
+behind either library. The OpenBLAS builds of the same versions are the
+`macosx_11_0_arm64` NumPy wheel and the `macosx_12_0_arm64` SciPy wheel:
 
 ```bash
 pip download "numpy==$(python -c 'import numpy; print(numpy.__version__)')" \
-    --platform macosx_11_0_arm64 --only-binary=:all: --no-deps -d /tmp/numpy-openblas
-pip install --force-reinstall --no-deps /tmp/numpy-openblas/*.whl
+    --platform macosx_11_0_arm64 --only-binary=:all: --no-deps -d /tmp/openblas-wheels
+pip download "scipy==$(python -c 'import scipy; print(scipy.__version__)')" \
+    --platform macosx_12_0_arm64 --only-binary=:all: --no-deps -d /tmp/openblas-wheels
+pip install --force-reinstall --no-deps /tmp/openblas-wheels/*.whl
 ```
 
 Set `MDOPT_ALLOW_ACCELERATE=1` to silence the warning if you must keep

--- a/mdopt/backend/array.py
+++ b/mdopt/backend/array.py
@@ -60,6 +60,49 @@ _xp = _load_backend()
 GPU = _xp.__name__ == "cupy"
 
 
+def _lapack_vendor(numpy_module) -> str:
+    """The LAPACK library NumPy was built against, lower-cased ('' if unknown)."""
+    try:
+        deps = numpy_module.show_config(mode="dicts")["Build Dependencies"]
+        return str(deps["lapack"]["name"]).lower()
+    except Exception:  # pylint: disable=broad-except
+        return ""
+
+
+def _warn_if_accelerate(numpy_module) -> None:
+    """Warn once when NumPy's LAPACK is Apple's Accelerate framework.
+
+    On the macOS arm64 wheels of NumPy 2.x (which link Accelerate) the
+    decoders' rank-deficient, wide-spectrum matrices made ``linalg.qr`` die
+    with SIGBUS and ``linalg.svd`` trip malloc's heap-corruption check
+    inside dgesdd, and a [[72,12,6]] decode at chi_max=400 returned wrong
+    verdicts while every unit test passed. The OpenBLAS build of the same
+    NumPy version has none of this; it is the ``macosx_11_0_arm64`` wheel::
+
+        pip download numpy==<version> --platform macosx_11_0_arm64 \
+            --only-binary=:all: --no-deps -d /tmp/numpy-openblas
+        pip install --force-reinstall --no-deps /tmp/numpy-openblas/*.whl
+
+    Set MDOPT_ALLOW_ACCELERATE=1 to silence the warning.
+    """
+    if os.getenv("MDOPT_ALLOW_ACCELERATE") == "1":
+        return
+    if "accelerate" in _lapack_vendor(numpy_module):
+        warnings.warn(
+            "NumPy is built against Apple's Accelerate LAPACK, which corrupted "
+            "memory and produced wrong decoding verdicts on mdopt's matrices "
+            "(see mdopt.backend.array._warn_if_accelerate). Install the "
+            "OpenBLAS build of NumPy (the macosx_11_0_arm64 wheel) or set "
+            "MDOPT_ALLOW_ACCELERATE=1 to silence this warning.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+if not GPU:
+    _warn_if_accelerate(_xp)
+
+
 # ----------------------------------------------------------------------
 # Introspection helpers
 # ----------------------------------------------------------------------

--- a/mdopt/backend/array.py
+++ b/mdopt/backend/array.py
@@ -99,8 +99,28 @@ def _warn_if_accelerate(numpy_module) -> None:
         )
 
 
+def _warn_if_scipy_accelerate() -> None:
+    """The same warning for SciPy, whose LAPACK the SVD helpers also call."""
+    if os.getenv("MDOPT_ALLOW_ACCELERATE") == "1":
+        return
+    try:
+        scipy = importlib.import_module("scipy")
+    except ImportError:
+        return
+    if "accelerate" in _lapack_vendor(scipy):
+        warnings.warn(
+            "SciPy is built against Apple's Accelerate LAPACK (see "
+            "mdopt.backend.array._warn_if_accelerate); install the OpenBLAS "
+            "build (the macosx_12_0_arm64 wheel) or set "
+            "MDOPT_ALLOW_ACCELERATE=1 to silence this warning.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
 if not GPU:
     _warn_if_accelerate(_xp)
+    _warn_if_scipy_accelerate()
 
 
 # ----------------------------------------------------------------------

--- a/tests/backend/test_array.py
+++ b/tests/backend/test_array.py
@@ -88,3 +88,32 @@ def test_stream_is_a_context_manager_on_numpy(monkeypatch):
     with module.stream():
         pass
     module.synchronize()
+
+
+def test_accelerate_lapack_warns_unless_allowed(monkeypatch):
+    """A NumPy built against Accelerate triggers a RuntimeWarning at import
+    time; MDOPT_ALLOW_ACCELERATE=1 silences it; other vendors are silent."""
+    import warnings
+    from types import SimpleNamespace
+
+    from mdopt.backend import array as backend
+
+    def fake_numpy(vendor):
+        return SimpleNamespace(
+            show_config=lambda mode="dicts": {
+                "Build Dependencies": {
+                    "lapack": {"name": vendor},
+                    "blas": {"name": vendor},
+                }
+            }
+        )
+
+    monkeypatch.delenv("MDOPT_ALLOW_ACCELERATE", raising=False)
+    with pytest.warns(RuntimeWarning, match="Accelerate"):
+        backend._warn_if_accelerate(fake_numpy("accelerate"))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        backend._warn_if_accelerate(fake_numpy("scipy-openblas"))
+        monkeypatch.setenv("MDOPT_ALLOW_ACCELERATE", "1")
+        backend._warn_if_accelerate(fake_numpy("accelerate"))
+    assert backend._lapack_vendor(SimpleNamespace()) == ""


### PR DESCRIPTION
On the macOS arm64 wheels of NumPy 2.x, which link Apple's Accelerate framework, mdopt's matrices (rank-deficient, singular values spanning many orders of magnitude) made `numpy.linalg.qr` die with SIGBUS and `numpy.linalg.svd` trip malloc's heap-corruption check inside `dgesdd` (crash reports from the [[72,12,6]] investigation on PR #543), and a `chi_max=400` bivariate-bicycle decode returned wrong verdicts while every unit test and benchmark fingerprint passed. Both the NumPy and the SciPy macOS wheels in that environment link Accelerate.

The OpenBLAS build of the same NumPy version (the `macosx_11_0_arm64` wheel) runs the same reproducers clean: the 200-call QR loop that died with SIGBUS every time exits normally with zero wrong factorisations, three runs out of three.

Changes:
- `mdopt.backend.array` warns once at import when Accelerate is found behind NumPy (`MDOPT_ALLOW_ACCELERATE=1` silences it); a test covers the three cases (Accelerate, another vendor, silenced).
- The README documents the two commands that install the OpenBLAS wheel and the per-process thread setting for worker pools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6mbxc9eJDQMVx7tjvYwud
